### PR TITLE
Require cmake 3.5 as minimum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(keyvalues)
 


### PR DESCRIPTION
A small change to avoid users having warnings/errors when used with cmake >3.20